### PR TITLE
Increase prompt size

### DIFF
--- a/ai-guess-game/src/main/resources/static/css/style.css
+++ b/ai-guess-game/src/main/resources/static/css/style.css
@@ -24,6 +24,7 @@ div.miss {
 
 .prompt {
     display: inline;
+    font-size: 1.5em;
 }
 
 .instructions {

--- a/ai-guess-game/src/main/resources/templates/game.html
+++ b/ai-guess-game/src/main/resources/templates/game.html
@@ -39,7 +39,7 @@
             <div>
                 <tbody>
                 <tr th:each="word : ${response}">
-                    <div th:text="${word.first}" th:class="${word.second}" class="prompt">prompt</div>
+                    <div th:text="${word.first}" th:class="@{'prompt ' + ${word.second}}">prompt</div>
                 </tr>
                 <tbody>
             </div>


### PR DESCRIPTION

# Purpose

This commit increases the prompt size so the player could more easily count the number of characters in each word. Moreover, it fixes a bug on the template that applied only the `hit`/`miss` CSS to each word and not the `prompt` style

# Types of changes

- [x] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
