### PR TITLE
[Feature] convert gradle build scripts to Kotlin DSL

### DIFF
--- a/beat-the-machine/build.gradle.kts
+++ b/beat-the-machine/build.gradle.kts
@@ -1,27 +1,10 @@
 plugins {
     id("jacoco")
-    id("pmd")
+    id("beat-the-machine.code-metrics")
     id("org.springframework.boot")
     id("io.spring.dependency-management")
     id("org.jetbrains.kotlin.jvm")
     id("org.jetbrains.kotlin.plugin.spring")
-    id("com.diffplug.spotless")
-}
-
-jar {
-    enabled = false
-}
-
-bootJar {
-    enabled = true
-}
-
-jar {
-    manifest {
-        attributes(
-                'Main-Class': 'com.yonatankarp.ai.guess.game.Application'
-        )
-    }
 }
 
 dependencies {
@@ -33,19 +16,25 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test") {
-        exclude group: "org.mockito", module: "mockito-core"
+        exclude("org.mockito:mockito-core")
     }
     testImplementation("io.mockk:mockk:1.13.2")
     testImplementation("com.ninja-squad:springmockk:3.1.1")
 }
 
-build {
-    finalizedBy spotlessApply
-}
+tasks {
+    getByName<Jar>("jar") {
+        enabled = false
+    }
 
-test {
-    useJUnitPlatform()
-    finalizedBy spotlessApply
-    finalizedBy jacocoTestReport
-    finalizedBy pmdTest
+    build {
+        finalizedBy(spotlessApply)
+    }
+
+    withType<Test> {
+        useJUnitPlatform()
+        finalizedBy(spotlessApply)
+        finalizedBy(jacocoTestReport)
+        finalizedBy(pmdTest)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,8 @@
 plugins {
-    id("jacoco")
-    id("pmd")
     id("beat-the-machine.java-conventions")
     id("beat-the-machine.code-metrics")
     id("beat-the-machine.publishing-conventions")
-    id("com.diffplug.spotless") version "6.11.0" apply true
+    id("com.diffplug.spotless") version "6.11.0" apply false
     id("org.springframework.boot") version "2.7.4" apply false
     id("io.spring.dependency-management") version "1.0.14.RELEASE" apply false
     id("org.jetbrains.kotlin.jvm") version "1.7.10" apply false

--- a/buildSrc/src/main/groovy/beat-the-machine.code-metrics.gradle
+++ b/buildSrc/src/main/groovy/beat-the-machine.code-metrics.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id("jacoco")
     id("pmd")
     id("com.diffplug.spotless")
 }
@@ -24,19 +23,7 @@ spotless {
 
 pmd {
     toolVersion = "6.42.0"
-    sourceSets = [sourceSets.main]
     reportsDir = file("$project.buildDir/reports/pmd")
     ruleSets = []
     ruleSetFiles = files("config/pmd/ruleset.xml")
-}
-
-jacoco {
-    toolVersion = "0.8.7"
-}
-
-jacocoTestReport {
-    reports {
-        xml.required = true
-        html.required = true
-    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,4 @@
 rootProject.name = "beat-the-machine"
-include 'beat-the-machine'
+include(
+    "beat-the-machine"
+)


### PR DESCRIPTION
# Purpose

This commit converts the build scripts to Kotlin DSL instead of Groovy DSL and fixes an issue with `code-metrics` plugin not being evaluated.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
