### PR TITLE
[Bugfix] Fix substring recognized as successful guess (Closes #7)

### DIFF
--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Guess.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Guess.kt
@@ -1,8 +1,8 @@
 package com.yonatankarp.beatthemachine.models
 
 data class Guess(var words: List<String>? = null) {
-    enum class GuessResult {
-        HIT,
-        MISS,
+    enum class GuessResult(val value: String) {
+        HIT("hit"),
+        MISS("miss"),
     }
 }

--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Riddle.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Riddle.kt
@@ -6,11 +6,11 @@ data class Riddle(val id: Int, val startPrompt: String, val prompt: String, val 
     fun giveUp() =
         this.prompt
             .split(" ")
-            .map { it to MISS.name }
+            .map { it to MISS }
 
     fun initPrompt() =
         this.startPrompt
             .split(" ")
-            .map { it to MISS.name }
+            .map { it to MISS }
             .toList()
 }

--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
@@ -1,9 +1,9 @@
 package com.yonatankarp.beatthemachine.services
 
 import com.yonatankarp.beatthemachine.models.Guess
+import com.yonatankarp.beatthemachine.models.Guess.GuessResult
 import com.yonatankarp.beatthemachine.models.Guess.GuessResult.HIT
 import com.yonatankarp.beatthemachine.models.Guess.GuessResult.MISS
-import com.yonatankarp.beatthemachine.utils.toHiddenString
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import kotlin.random.Random
@@ -12,30 +12,29 @@ import kotlin.random.Random
 class RiddleService {
 
     companion object {
+        private const val MASK_CHARACTER = "-"
+
         private val log = LoggerFactory.getLogger(RiddleService::class.java)
+        private val WHITESPACE_REGEX = """\s+""".toRegex()
     }
 
-    fun handleGuess(id: Int, guess: Guess): List<Pair<String, String>> {
+    fun handleGuess(id: Int, guess: Guess): List<Pair<String, GuessResult>> {
         val riddle = getRiddle(id)
         if (guess.words == null) return riddle.initPrompt()
 
-        val riddlePhrase = riddle.prompt.split(" ")
-        val guessPhrase = guess.words!!.joinToString(separator = " ")
-
-        val results = mutableListOf<Pair<String, String>>()
-
-        riddlePhrase.forEach { word ->
-            results += if (guessPhrase.contains(word, ignoreCase = true)) {
-                word to HIT.name
-            } else {
-                word.toHiddenString() to MISS.name
-            }
-        }
-
-        log.info("Phrase '$riddlePhrase' with guess $guess have the results: $results")
-
-        return results
+        return maskNoneGuessedWords(guess.words, riddle.prompt)
+            .also { log.info("Phrase '${riddle.prompt}' with guess $guess have the results: $it") }
     }
+
+    fun maskNoneGuessedWords(words: List<String>?, prompt: String): List<Pair<String, GuessResult>> =
+        prompt.lowercase().split(WHITESPACE_REGEX)
+            .map { word ->
+                if (words?.contains(word) == true) {
+                    word to HIT
+                } else {
+                    MASK_CHARACTER.repeat(word.length) to MISS
+                }
+            }
 
     fun getRiddle(id: Int) = RiddleManager.riddles[id]
 

--- a/beat-the-machine/src/main/resources/templates/game.html
+++ b/beat-the-machine/src/main/resources/templates/game.html
@@ -29,9 +29,7 @@
     <img th:src="${riddle.url}" class="img-thumbnail" width="500" alt="generated image"/>
 </div>
 <div class="center">
-#pragma warning disable S3881
     <!--/*@thymesVar id="owner" type="com.yonatankarp.beatthemachine.models.Guess"*/-->
-#pragma warning restore S3881
     <form action="#" th:action="@{'/' + ${riddle.id} + '/guess'}" th:object="${guess}" method="post">
         <div class="mb-3">
             <label class="form-label">Guess:</label>
@@ -42,7 +40,7 @@
             <div>
                 <tbody>
                 <tr th:each="word : ${response}">
-                    <div th:text="${word.first}" th:class="@{'prompt ' + ${word.second}}">prompt</div>
+                    <div th:text="${word.first}" th:class="@{'prompt ' + ${word.second.value}}">prompt</div>
                 </tr>
                 <tbody>
             </div>

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleControllerTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleControllerTest.kt
@@ -50,7 +50,7 @@ class RiddleControllerTest {
                 model {
                     attribute("guess", Guess(emptyList()))
                     attribute("riddle", riddle)
-                    attribute("response", listOf("---" to GuessResult.MISS.name))
+                    attribute("response", listOf("---" to GuessResult.MISS))
                 }
             }
 
@@ -73,11 +73,11 @@ class RiddleControllerTest {
                     attribute(
                         "response",
                         listOf(
-                            "a" to GuessResult.MISS.name,
-                            "man" to GuessResult.MISS.name,
-                            "on" to GuessResult.MISS.name,
-                            "the" to GuessResult.MISS.name,
-                            "moon" to GuessResult.MISS.name,
+                            "a" to GuessResult.MISS,
+                            "man" to GuessResult.MISS,
+                            "on" to GuessResult.MISS,
+                            "the" to GuessResult.MISS,
+                            "moon" to GuessResult.MISS,
                         ),
                     )
                 }
@@ -92,10 +92,10 @@ class RiddleControllerTest {
         val riddle = RiddleManager.riddles[riddleId]
         val guess = Guess()
         val guessHits = listOf(
-            "dragon" to GuessResult.MISS.name,
-            "eating" to GuessResult.MISS.name,
-            "a" to GuessResult.MISS.name,
-            "cookie" to GuessResult.MISS.name,
+            "dragon" to GuessResult.MISS,
+            "eating" to GuessResult.MISS,
+            "a" to GuessResult.MISS,
+            "cookie" to GuessResult.MISS,
         )
         every { service.handleGuess(any(), any()) } returns guessHits
 

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/models/RiddleTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/models/RiddleTest.kt
@@ -17,7 +17,7 @@ class RiddleTest {
         // Then
         riddle.prompt.split(" ").forEachIndexed { i, word ->
             assertEquals(word, actual[i].first)
-            assertEquals(MISS.name, actual[i].second)
+            assertEquals(MISS, actual[i].second)
         }
     }
 
@@ -32,7 +32,7 @@ class RiddleTest {
         // Then
         actual.forEach {
             assertEquals("---", it.first)
-            assertEquals(MISS.name, it.second)
+            assertEquals(MISS, it.second)
         }
     }
 }

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
@@ -14,7 +14,7 @@ class RiddleServiceTest {
 
     @ParameterizedTest
     @MethodSource("provideTestData")
-    fun `should map guess to results`(id: Int, guess: Guess, expected: List<Pair<String, String>>) {
+    fun `should map guess to results`(id: Int, guess: Guess, expected: List<Pair<String, GuessResult>>) {
         val actual = service.handleGuess(id, guess)
         assertEquals(expected, actual)
     }
@@ -26,44 +26,44 @@ class RiddleServiceTest {
                 0,
                 Guess(listOf("incorrect guess")),
                 listOf(
-                    "---" to GuessResult.MISS.name,
-                    "------" to GuessResult.MISS.name,
-                    "--" to GuessResult.MISS.name,
-                    "-" to GuessResult.MISS.name,
-                    "---" to GuessResult.MISS.name,
+                    "---" to GuessResult.MISS,
+                    "------" to GuessResult.MISS,
+                    "--" to GuessResult.MISS,
+                    "-" to GuessResult.MISS,
+                    "---" to GuessResult.MISS,
                 ),
             ),
             Arguments.of(
                 0,
                 Guess(listOf("man")),
                 listOf(
-                    "man" to GuessResult.HIT.name,
-                    "------" to GuessResult.MISS.name,
-                    "--" to GuessResult.MISS.name,
-                    "a" to GuessResult.HIT.name, // TODO: fix after fixing word recognition
-                    "man" to GuessResult.HIT.name,
+                    "man" to GuessResult.HIT,
+                    "------" to GuessResult.MISS,
+                    "--" to GuessResult.MISS,
+                    "-" to GuessResult.MISS,
+                    "man" to GuessResult.HIT,
                 ),
             ),
             Arguments.of(
                 0,
-                Guess(listOf("man stands on a man")),
+                Guess("man stands on a man".split(" ")),
                 listOf(
-                    "man" to GuessResult.HIT.name,
-                    "stands" to GuessResult.HIT.name,
-                    "on" to GuessResult.HIT.name,
-                    "a" to GuessResult.HIT.name,
-                    "man" to GuessResult.HIT.name,
+                    "man" to GuessResult.HIT,
+                    "stands" to GuessResult.HIT,
+                    "on" to GuessResult.HIT,
+                    "a" to GuessResult.HIT,
+                    "man" to GuessResult.HIT,
                 ),
             ),
             Arguments.of(
                 0,
                 Guess(null),
                 listOf(
-                    "---" to GuessResult.MISS.name,
-                    "------" to GuessResult.MISS.name,
-                    "--" to GuessResult.MISS.name,
-                    "-" to GuessResult.MISS.name,
-                    "---" to GuessResult.MISS.name,
+                    "---" to GuessResult.MISS,
+                    "------" to GuessResult.MISS,
+                    "--" to GuessResult.MISS,
+                    "-" to GuessResult.MISS,
+                    "---" to GuessResult.MISS,
                 ),
             ),
         )


### PR DESCRIPTION


# Purpose

This commit fixes an issue where a substring of the guess was also marked as a successful guess (e.g. `man watching a man` with the guess `man` would mark both `man` and `a` as a successful guess)

Moreover, it fixes a UI issue that did not color the prompt with its colors (red for masked words and greed for correctly guessed words) (Closes #58)

# Types of changes

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
