### PR TITLE
[Bugfix] Guess miss because of case sensitivity

### DIFF
--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
@@ -22,14 +22,16 @@ class RiddleService {
         val riddle = getRiddle(id)
         if (guess.words == null) return riddle.initPrompt()
 
-        return maskNoneGuessedWords(guess.words, riddle.prompt)
+        val guesses = guess.words?.map { it.lowercase() }?.toList() ?: emptyList()
+
+        return maskNoneGuessedWords(guesses, riddle.prompt)
             .also { log.info("Phrase '${riddle.prompt}' with guess $guess have the results: $it") }
     }
 
-    fun maskNoneGuessedWords(words: List<String>?, prompt: String): List<Pair<String, GuessResult>> =
+    fun maskNoneGuessedWords(words: List<String>, prompt: String): List<Pair<String, GuessResult>> =
         prompt.lowercase().split(WHITESPACE_REGEX)
             .map { word ->
-                if (words?.contains(word) == true) {
+                if (words.contains(word)) {
                     word to HIT
                 } else {
                     MASK_CHARACTER.repeat(word.length) to MISS

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
@@ -46,6 +46,17 @@ class RiddleServiceTest {
             ),
             Arguments.of(
                 0,
+                Guess(listOf("Man")),
+                listOf(
+                    "man" to GuessResult.HIT,
+                    "------" to GuessResult.MISS,
+                    "--" to GuessResult.MISS,
+                    "-" to GuessResult.MISS,
+                    "man" to GuessResult.HIT,
+                ),
+            ),
+            Arguments.of(
+                0,
                 Guess("man stands on a man".split(" ")),
                 listOf(
                     "man" to GuessResult.HIT,


### PR DESCRIPTION

# Purpose

This commit fixes a bug where the guesses have missed the prompt because of case-sensitivity comparison (e.g. guess `Man` for prompt `man watch the sky` would return `--- ----- --- ---`.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [ ] No new tests are needed
