### PR TITLE
[Bugfix] Check guesses by string tokens

### DIFF
--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleController.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleController.kt
@@ -1,6 +1,7 @@
 package com.yonatankarp.beatthemachine.controllers
 
-import com.yonatankarp.beatthemachine.models.Guess
+import com.yonatankarp.beatthemachine.models.GuessRequest
+import com.yonatankarp.beatthemachine.models.GuessResponse
 import com.yonatankarp.beatthemachine.services.RiddleManager
 import com.yonatankarp.beatthemachine.services.RiddleService
 import org.slf4j.LoggerFactory
@@ -23,7 +24,7 @@ class RiddleController(
     fun index(model: Model): String {
         log.info("Loading index...")
         riddleService.getRandomRiddle().let {
-            model.addAttribute("guess", Guess(emptyList()))
+            model.addAttribute("guess", GuessResponse(emptyList()))
             model.addAttribute("riddle", it)
             model.addAttribute("response", it.initPrompt())
         }
@@ -34,7 +35,7 @@ class RiddleController(
     fun iGiveUp(@PathVariable id: Int, model: Model): String {
         log.info("Giving up on riddle id: $id")
         riddleService.getRiddle(id.toRiddleId()).let {
-            model.addAttribute("guess", Guess(listOf()))
+            model.addAttribute("guess", GuessResponse(listOf()))
             model.addAttribute("riddle", it)
             model.addAttribute("response", it.giveUp())
         }
@@ -43,7 +44,7 @@ class RiddleController(
     }
 
     @PostMapping("/{id}/guess")
-    fun submitGuess(@PathVariable id: Int, @ModelAttribute guess: Guess, model: Model): String {
+    fun submitGuess(@PathVariable id: Int, @ModelAttribute guess: GuessRequest, model: Model): String {
         val riddleId = id.toRiddleId()
         log.info("Guess for id $riddleId is ${guess.words}")
         riddleService.handleGuess(riddleId, guess)

--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/GuessResponse.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/GuessResponse.kt
@@ -1,6 +1,8 @@
 package com.yonatankarp.beatthemachine.models
 
-data class Guess(var words: List<String>? = null) {
+data class GuessRequest(var words: String? = null)
+
+data class GuessResponse(var words: List<String>? = null) {
     enum class GuessResult(val value: String) {
         HIT("hit"),
         MISS("miss"),

--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Riddle.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/models/Riddle.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.beatthemachine.models
 
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult.MISS
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult.MISS
 
 data class Riddle(val id: Int, val startPrompt: String, val prompt: String, val url: String) {
     fun giveUp() =

--- a/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
+++ b/beat-the-machine/src/main/kotlin/com/yonatankarp/beatthemachine/services/RiddleService.kt
@@ -1,9 +1,9 @@
 package com.yonatankarp.beatthemachine.services
 
-import com.yonatankarp.beatthemachine.models.Guess
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult.HIT
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult.MISS
+import com.yonatankarp.beatthemachine.models.GuessRequest
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult.HIT
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult.MISS
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import kotlin.random.Random
@@ -18,14 +18,14 @@ class RiddleService {
         private val WHITESPACE_REGEX = """\s+""".toRegex()
     }
 
-    fun handleGuess(id: Int, guess: Guess): List<Pair<String, GuessResult>> {
+    fun handleGuess(id: Int, guess: GuessRequest): List<Pair<String, GuessResult>> {
         val riddle = getRiddle(id)
-        if (guess.words == null) return riddle.initPrompt()
+        return guess.words?.let {
+            val guesses = guess.words?.split(" ")?.map { it.lowercase() }?.toList() ?: emptyList()
 
-        val guesses = guess.words?.map { it.lowercase() }?.toList() ?: emptyList()
-
-        return maskNoneGuessedWords(guesses, riddle.prompt)
-            .also { log.info("Phrase '${riddle.prompt}' with guess $guess have the results: $it") }
+            return maskNoneGuessedWords(guesses, riddle.prompt)
+                .also { log.info("Phrase '${riddle.prompt}' with guess $guess have the results: $it") }
+        } ?: riddle.initPrompt()
     }
 
     fun maskNoneGuessedWords(words: List<String>, prompt: String): List<Pair<String, GuessResult>> =

--- a/beat-the-machine/src/main/resources/templates/game.html
+++ b/beat-the-machine/src/main/resources/templates/game.html
@@ -29,7 +29,7 @@
     <img th:src="${riddle.url}" class="img-thumbnail" width="500" alt="generated image"/>
 </div>
 <div class="center">
-    <!--/*@thymesVar id="owner" type="com.yonatankarp.beatthemachine.models.Guess"*/-->
+    <!--/*@thymesVar id="owner" type="com.yonatankarp.beatthemachine.models.GuessResponse"*/-->
     <form action="#" th:action="@{'/' + ${riddle.id} + '/guess'}" th:object="${guess}" method="post">
         <div class="mb-3">
             <label class="form-label">Guess:</label>

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleControllerTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/controllers/RiddleControllerTest.kt
@@ -1,8 +1,9 @@
 package com.yonatankarp.beatthemachine.controllers
 
 import com.ninjasquad.springmockk.MockkBean
-import com.yonatankarp.beatthemachine.models.Guess
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult
+import com.yonatankarp.beatthemachine.models.GuessRequest
+import com.yonatankarp.beatthemachine.models.GuessResponse
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult
 import com.yonatankarp.beatthemachine.models.Riddle
 import com.yonatankarp.beatthemachine.services.RiddleManager
 import com.yonatankarp.beatthemachine.services.RiddleService
@@ -48,7 +49,7 @@ class RiddleControllerTest {
                 status { isOk() }
                 view { name("index") }
                 model {
-                    attribute("guess", Guess(emptyList()))
+                    attribute("guess", GuessResponse(emptyList()))
                     attribute("riddle", riddle)
                     attribute("response", listOf("---" to GuessResult.MISS))
                 }
@@ -68,7 +69,7 @@ class RiddleControllerTest {
                 status { isOk() }
                 view { name("game") }
                 model {
-                    attribute("guess", Guess(emptyList()))
+                    attribute("guess", GuessResponse(emptyList()))
                     attribute("riddle", riddle)
                     attribute(
                         "response",
@@ -90,7 +91,7 @@ class RiddleControllerTest {
     fun `should submit guess`() {
         val riddleId = 4
         val riddle = RiddleManager.riddles[riddleId]
-        val guess = Guess()
+        val guess = GuessRequest()
         val guessHits = listOf(
             "dragon" to GuessResult.MISS,
             "eating" to GuessResult.MISS,
@@ -105,12 +106,9 @@ class RiddleControllerTest {
             status { isOk() }
             view { name("game") }
             model {
-                attribute("guess", guess)
+                attribute("guess", GuessRequest())
                 attribute("riddle", riddle)
-                attribute(
-                    "response",
-                    guessHits,
-                )
+                attribute("response", guessHits)
             }
         }
 

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/models/RiddleTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/models/RiddleTest.kt
@@ -1,6 +1,6 @@
 package com.yonatankarp.beatthemachine.models
 
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult.MISS
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult.MISS
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 

--- a/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
+++ b/beat-the-machine/src/test/kotlin/com/yonatankarp/beatthemachine/services/RiddleServiceTest.kt
@@ -1,7 +1,7 @@
 package com.yonatankarp.beatthemachine.services
 
-import com.yonatankarp.beatthemachine.models.Guess
-import com.yonatankarp.beatthemachine.models.Guess.GuessResult
+import com.yonatankarp.beatthemachine.models.GuessRequest
+import com.yonatankarp.beatthemachine.models.GuessResponse.GuessResult
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -14,7 +14,11 @@ class RiddleServiceTest {
 
     @ParameterizedTest
     @MethodSource("provideTestData")
-    fun `should map guess to results`(id: Int, guess: Guess, expected: List<Pair<String, GuessResult>>) {
+    fun `should map guess to results`(
+        id: Int,
+        guess: GuessRequest,
+        expected: List<Pair<String, GuessResult>>,
+    ) {
         val actual = service.handleGuess(id, guess)
         assertEquals(expected, actual)
     }
@@ -24,7 +28,7 @@ class RiddleServiceTest {
         fun provideTestData(): Stream<Arguments> = Stream.of(
             Arguments.of(
                 0,
-                Guess(listOf("incorrect guess")),
+                GuessRequest("incorrect guess"),
                 listOf(
                     "---" to GuessResult.MISS,
                     "------" to GuessResult.MISS,
@@ -35,7 +39,7 @@ class RiddleServiceTest {
             ),
             Arguments.of(
                 0,
-                Guess(listOf("man")),
+                GuessRequest("man"),
                 listOf(
                     "man" to GuessResult.HIT,
                     "------" to GuessResult.MISS,
@@ -46,7 +50,7 @@ class RiddleServiceTest {
             ),
             Arguments.of(
                 0,
-                Guess(listOf("Man")),
+                GuessRequest("Man"),
                 listOf(
                     "man" to GuessResult.HIT,
                     "------" to GuessResult.MISS,
@@ -57,7 +61,7 @@ class RiddleServiceTest {
             ),
             Arguments.of(
                 0,
-                Guess("man stands on a man".split(" ")),
+                GuessRequest("man stands on a man"),
                 listOf(
                     "man" to GuessResult.HIT,
                     "stands" to GuessResult.HIT,
@@ -68,7 +72,7 @@ class RiddleServiceTest {
             ),
             Arguments.of(
                 0,
-                Guess(null),
+                GuessRequest(null),
                 listOf(
                     "---" to GuessResult.MISS,
                     "------" to GuessResult.MISS,


### PR DESCRIPTION

# Purpose

This commit ensures that the guesses from the user are tested as a token (e.g. the guesses string `man on a wall` would be split into `man`, `on`, `a`, `wall`).

Moreover, this commit ensures separation between request and response types


# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [ ] No new tests are needed
