### PR TITLE
Add java version to gradle upgrade workflow

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -15,6 +15,12 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           fetch-depth: 0
+          
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'          
 
       - name: Update Gradle Wrapper
         # **WARN**: as this action comes from the org without public members,


### PR DESCRIPTION

# Purpose

This commit sets up the java version on the Gradle upgrader workflow in an attempt to ensure that the version running during the upgrade is 17 (which is required for the project at this point as the minimal version of java)


# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
