### PR TITLE
Hardcode application name in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
 jobs:
   pipeline:
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
+    with:
+      app_name: beat-the-machine
+        
 
   dependabot_auto_merge:
     needs: pipeline


### PR DESCRIPTION


# Purpose

as this project is deprecated, the name was changed and broke CI, this commit changes the name on github actions to be hard-coded to the name of the product (`beat-the-machine`) as this is where the docker file is located.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
