### PR TITLE
Remove duplicate markdown lint config

### DIFF
--- a/config/markdown-lint/rules.json
+++ b/config/markdown-lint/rules.json
@@ -1,7 +1,0 @@
-{
-  "MD013": {
-    "line_length": 80,
-    "code_block_line_length": 120,
-    "tables": false
-  }
-}


### PR DESCRIPTION
## Summary
- remove the local markdown-lint rules copy
- rely on the shared github-actions linter defaults

## Validation
- verified no remaining workflow references to the deleted config path